### PR TITLE
Allow unknown file extensions, fixes #11

### DIFF
--- a/commands/util.js
+++ b/commands/util.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs');
 var glob = require('glob');
 var path = require('path');
 
@@ -31,8 +32,13 @@ function getFiles(args) {
 
 function openFile(filename, suffix){
     var json = null;
+    var file = path.resolve(process.cwd(), filename);
     try {
-        json = require(path.resolve(process.cwd(), filename));
+        if (endsWith(filename, 'json') || endsWith(filename, 'js')) {
+            json = require(file);
+        } else {
+            json = JSON.parse(fs.readFileSync(file).toString());
+        }
     } catch(err) {
         console.error('error:  ' + err.message.replace(' module', ' ' + suffix));
         process.exit(2);
@@ -60,4 +66,9 @@ function compile(ajv, schemaFile) {
         console.error('error:', err.message);
         process.exit(1);
     }
+}
+
+
+function endsWith(str, suffix) {
+    return str.substr(-suffix.length) === suffix;
 }

--- a/commands/util.js
+++ b/commands/util.js
@@ -34,11 +34,8 @@ function openFile(filename, suffix){
     var json = null;
     var file = path.resolve(process.cwd(), filename);
     try {
-        if (endsWith(filename, 'json') || endsWith(filename, 'js')) {
-            json = require(file);
-        } else {
-            json = JSON.parse(fs.readFileSync(file).toString());
-        }
+        if (endsWith(filename, 'json') || endsWith(filename, 'js')) json = require(file);
+        else json = JSON.parse(fs.readFileSync(file).toString());
     } catch(err) {
         console.error('error:  ' + err.message.replace(' module', ' ' + suffix));
         process.exit(2);


### PR DESCRIPTION
This will resolve #11 by falling back to trying to JSON parse a file with a different extension (if it's not a JS or JSON file).

I tested the use case in the issue and can confirm that this fixes. 