### PR TITLE
Correct Code Climate Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Command line interface for [ajv](https://github.com/epoberezkin/ajv), one of the
 
 [![Build Status](https://travis-ci.org/jessedc/ajv-cli.svg?branch=master)](https://travis-ci.org/jessedc/ajv-cli)
 [![npm version](https://badge.fury.io/js/ajv-cli.svg)](https://www.npmjs.com/package/ajv-cli)
-[![Code Climate](https://codeclimate.com/github/epoberezkin/ajv-cli/badges/gpa.svg)](https://codeclimate.com/github/epoberezkin/ajv-cli)
+[![Code Climate](https://codeclimate.com/github/jessedc/ajv-cli/badges/gpa.svg)](https://codeclimate.com/github/jessedc/ajv-cli)
 [![Coverage Status](https://coveralls.io/repos/github/jessedc/ajv-cli/badge.svg?branch=master)](https://coveralls.io/github/jessedc/ajv-cli?branch=master)
 
 


### PR DESCRIPTION
The code climate badge was looking at epoberezkin/ajv-cli instead of jessedc/ajv-cli.