### PR TITLE
Drop support for node <8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 before_script:
   - npm install -g codeclimate-test-reporter
 node_js:
-  - "4"
-  - "6"
-  - "7"
+  - "8"
+  - "10"
+  - "12"
 after_script:
   - codeclimate-test-reporter < coverage/lcov.info
   - coveralls < coverage/lcov.info


### PR DESCRIPTION
This is what's causing the coverage to change so drastically in #66 - b/c the tests fail against node@4, there's no coverage!